### PR TITLE
Reduce rent and burn

### DIFF
--- a/sdk/program/src/fee_calculator.rs
+++ b/sdk/program/src/fee_calculator.rs
@@ -71,11 +71,11 @@ pub struct FeeRateGovernor {
     pub burn_percent: u8,
 }
 
-pub const DEFAULT_TARGET_LAMPORTS_PER_SIGNATURE: u64 = 10_000;
+pub const DEFAULT_TARGET_LAMPORTS_PER_SIGNATURE: u64 = 100;
 pub const DEFAULT_TARGET_SIGNATURES_PER_SLOT: u64 = 50 * DEFAULT_MS_PER_SLOT;
 
 // Percentage of tx fees to burn
-pub const DEFAULT_BURN_PERCENT: u8 = 50;
+pub const DEFAULT_BURN_PERCENT: u8 = 0;
 
 impl Default for FeeRateGovernor {
     fn default() -> Self {

--- a/sdk/program/src/rent.rs
+++ b/sdk/program/src/rent.rs
@@ -29,9 +29,10 @@ pub struct Rent {
 /// This calculation is based on:
 /// - 10^9 lamports per SOL
 /// - $1 per SOL
-/// - $0.01 per megabyte day
-/// - $3.65 per megabyte year
-pub const DEFAULT_LAMPORTS_PER_BYTE_YEAR: u64 = 1_000_000_000 / 100 * 365 / (1024 * 1024);
+/// - $0.0001 per megabyte day (100 times cheaper than the original cost)
+/// - $0.0365 per megabyte year (100 times cheaper than the original cost)
+pub const DEFAULT_LAMPORTS_PER_BYTE_YEAR: u64 = 1_000_000_000 / 10_000 * 365 / (1024 * 1024);
+
 
 /// Default amount of time (in years) the balance has to include rent for the
 /// account to be rent exempt.
@@ -41,7 +42,7 @@ pub const DEFAULT_EXEMPTION_THRESHOLD: f64 = 2.0;
 ///
 /// Valid values are in the range [0, 100]. The remaining percentage is
 /// distributed to validators.
-pub const DEFAULT_BURN_PERCENT: u8 = 50;
+pub const DEFAULT_BURN_PERCENT: u8 = 0;
 
 /// Account storage overhead for calculation of base rent.
 ///


### PR DESCRIPTION
Reduce fee burn to 0, lower rent to 100th of original cost. Also, lowers target lamports per signature.
