### PR TITLE
[feature] #4: BLS12-381 native instruction and native program 

### DIFF
--- a/programs/bls12-381-tests/tests/process_transaction.rs
+++ b/programs/bls12-381-tests/tests/process_transaction.rs
@@ -1,4 +1,4 @@
-use solana_sdk::bls12_381_instruction::{pair::GeneratorPoint, SignKey, VerKey};
+use solana_sdk::bls12_381_instruction::{algebra::GeneratorPoint, SignKey, VerKey};
 
 use {
     solana_program_test::*,

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -711,7 +711,7 @@ pub mod tests {
     }
 
     impl AppendVecStoredAccountMeta<'_> {
-        #[allow(clippy::cast_ref_to_mut)]
+        #![allow(cast_ref_to_mut)]
         fn set_data_len_unsafe(&self, new_data_len: u64) {
             // UNSAFE: cast away & (= const ref) to &mut to force to mutate append-only (=read-only) AppendVec
             unsafe {
@@ -726,7 +726,6 @@ pub mod tests {
             executable_byte
         }
 
-        #[allow(clippy::cast_ref_to_mut)]
         fn set_executable_as_byte(&self, new_executable_byte: u8) {
             // UNSAFE: Force to interpret mmap-backed &bool as &u8 to write some crafted value;
             unsafe {

--- a/sdk/program/src/bls12_381_program.rs
+++ b/sdk/program/src/bls12_381_program.rs
@@ -1,0 +1,5 @@
+//! The [bls12-381 native program][np].
+//!
+//! [np]: https://docs.solana.com/developing/runtime-facilities/programs#ed25519-program
+
+crate::declare_id!("BLS12381SigVerify11111111111111111111111111");

--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -486,6 +486,7 @@ pub mod clock;
 pub mod debug_account_data;
 pub mod decode_error;
 pub mod ed25519_program;
+pub mod bls12_381_program;
 pub mod entrypoint;
 pub mod entrypoint_deprecated;
 pub mod epoch_schedule;

--- a/sdk/src/bls12-381.md
+++ b/sdk/src/bls12-381.md
@@ -285,4 +285,98 @@ All of the structures use the `amcl` representation for the underlying
 type.  It is useful for interoperability with other `amcl`-based
 implementations, but violating these assumptions is not a problem.
 
-## 
+## Overall remarks
+
+The code is supplied with sufficient API documentation so as not to
+need detailed explanations.  One decision that is difficult to
+rationalise in-code is the choice to return byte vectors rather than
+fixed byte arrays.  The reason for that is two-fold.  The underlying
+`amcl` objects do not guarantee bound checking, as such, having the
+ability to catch these errors early, by pre-allocating a dynamical
+array first allows for more flexibility.  This is subject to change,
+especially given more testing. 
+
+The choice was made to give the signing facility to the `SignKey`.
+This is a rather arbitrary choice, save for the fact that signing
+keys' main function is to sign messages.  Similarly, it is the
+`Signature`'s main function to be verified, hence why the verify
+facility is given to it along side the `VerKey`.  The API of the
+library can use a bit more refinement, and any suggestions on the
+aspects of the API that can be improved are welcome (one avenue to be
+explored given more time is extension traits for signing and
+verifying, or perhaps a builder pattern). 
+
+## Instruction
+
+In order to expose the new functionality to the Solana application
+binary interface, in order to execute certain operations in parallel,
+and extract some logic out of the Solana programs making use of the
+functionality, one should make use of the facilities provided in the
+`instruction` module. 
+
+This module is largely built around a single function
+`new_bls_12_381_instruction`, which, as its name suggests, produces
+the relevant instruction using offsets defined as constants.  The
+function is an adaptation of a similar function named
+`new_ed25519_instruction` from the respective `ed25519_instruction.rs`
+module in the same directory.  This function does not panic in a
+`release` build, and its static assertions (given that they cannot be
+"sometimes violated") are disabled. 
+
+This function forwards any issues with the signature process, and
+packs into a single byte buffer the following data in order;
+- `num_signatures` hard coded to `1u8` and unused, 
+- padding byte, for alignment to a `u16` boundary. 
+- `offsets` which is an instance of the `Bls12381SignatureOffsets`
+  which shall be covered later. 
+- `pubkey` which is the `VerKey` that corresponds to the
+  `key_pair.verify` half. 
+- `signature` which is the single signature to be sent via the
+  instruction. 
+- `message_data` which is the message represented as a slice of `u8`
+  (without the null terminator).
+
+The sizes of the data locations must be known exactly and must be
+aligned correctly so that `bytemuck` can create the appropriate
+buffer. 
+
+Here the data structure `Bls12381SignatureOffsets` is the following
+data structure (included for posterity). 
+```rust
+#[derive(Default, Debug, Copy, Clone, Zeroable, Pod, Eq, PartialEq)]
+#[repr(C)]
+pub struct Bls12381SignatureOffsets {
+    /// Offset to ed25519 signature of 64 bytes
+    signature_offset: u16,
+    /// Instruction index to find signature
+    signature_instruction_index: u16,
+    /// Offset to public key of 32 bytes
+    public_key_offset: u16,
+    /// Instruction index to find public key
+    public_key_instruction_index: u16,
+    /// Offset to start of message data
+    message_data_offset: u16,
+    /// Size of message data
+    message_data_size: u16,
+    /// Index of instruction data to get message data
+    message_instruction_index: u16,
+}
+```
+
+It is provided for decoding purposes only, and for ABI standardisation
+across Solana Elliptic curve native programs.  This structure contains
+many placeholder values and the precise offsets need to be verified
+during code review. So far, the implementation seems consistent with
+the included assertions. 
+
+## Remaining work
+
+The example Solana program has demonstrated problematic performance.
+The sizes of most structures are too large to be practical, and it is
+mostly up for debate whether or not the offsets are computed in a
+future-proof manner.  As is, the work cannot be up-streamed into
+Solana.  Any attempt at an earnest upstream-able implementation must
+include threshold signatures and multi-signatures, as well as some
+facilities for zero-knowledge verification. 
+
+Further the list of example programs is incomplete. 

--- a/sdk/src/bls12-381.md
+++ b/sdk/src/bls12-381.md
@@ -115,4 +115,104 @@ fn init () -> {
 #### KeyPair
 
 Using a `GeneratorPoint` one can generate a pair of keys, which can
-then be tracked together or separately. This is for the use-case of 
+then be tracked together or separately. This is for the use-case of
+dispensing the keys in one location, or creating session keys. 
+
+However, often it is necessary to generate a private key from a seed
+phrase, and then to be able to generate various public keys for
+various applications, such that the user only need track one key for
+multiple networks and applications; for that purpose, it is useful to
+derive the `SignKey` directly. 
+
+```rust
+let seed_phrase = b"Do not hard-code this phrase, usually it's always good to\
+                    import it from safe password-protected storage,\
+                    or a hardware security module";
+let private_key = SignKey::new(Some(seed_phrase));
+```
+
+Then, if say the user needs a public key for Network A, they can
+derive the `VerKey` in place:
+
+```rust
+let public_key = VerKey::new(network_a_generator_point, &private_key);
+```
+
+Here note that we recommend using a longer seed phrase for the
+exchange. The phrase must be at least `32` bytes long, otherwise the
+cryptography is compromised. 
+
+### Signature verification example
+
+After having generated the keys it is time to walk through an example
+of sig-verify. 
+
+
+```rust
+let message = b"Hello world!";
+
+// New and session-local generator point.  These generator points can
+// be exchanged periodically alongside the `VerKey`s correspoding to
+// the same accounts.  It is not possible to derive a new `VerKey`
+// given the old `GeneratorPoint` and the new `GeneratorPoint`.
+let gen = GeneratorPoint::new();
+
+// Random seed is the most cryptographically secure.  Explicitly not
+// using a seed allows efficient internal randomisation.
+let sign_key = SignKey::new(None).unwrap();
+let ver_key = VerKey::new(gen, &sign_key);
+
+let signature = sign_key.sign(&message).unwrap();
+// TODO: it is also natural to expect `message`.sign(&sign_key)`. 
+
+assert!(
+    signature.verify(&message, &ver_key, gen).unwrap(),
+    "Failed to verify signature for message [1,2,3,4,5]"
+);
+
+let different_message = [2, 3, 4, 5, 6];
+
+let different_message_signature = sign_key.sign(&different_message).unwrap();
+assert!(
+    different_message_signature
+    .verify(&different_message, &ver_key, gen)
+    .unwrap(),
+    "Couldn't verify the signature on `different_message`, probably because the signature has become non-deterministic."
+);
+assert!(!different_message_signature
+    .verify(&message, &ver_key, gen)
+    .unwrap(),
+    "The signature for two different trivial messages is the exact same. This should never happen, and you should report it"
+);
+
+```
+
+In the first line we are generating a session for the exchange, in a
+real example, one would have to separately exchange the
+`GeneratorPoint`, the `ver_key`, and the message should come with
+neither of those things.  It is also possible that the `gen` is
+pre-existing and all parties have exchanged the seed phrase before
+initiating the exchange. 
+
+### Using the Instruction
+
+As is, the implementation is compiled to a BPF representation and
+statically linked against the Solana program that wishes to either
+sign or verify the messages.  This is relatively efficient for single
+signatures, and is effectively the same overhead as one would expect
+from a Solana native program.  However there are instances, where it
+might be useful to define a Solana native program that handles the
+Signing and verification parts of the exchange. 
+
+For this purpose, an example Solana program is provided that utilises
+the features exposed in the modification.  It is by far not complete,
+and had not been extensively tested, to the effect, that no behaviour
+outside the ones tested in `bls12_381_instruction.rs::sig_verify` were
+tested. 
+
+
+
+# Code Details
+
+In this section I shall explain some of the aspects of the
+implementation so that the code is easier to maintain. 

--- a/sdk/src/bls12-381.md
+++ b/sdk/src/bls12-381.md
@@ -51,14 +51,15 @@ verify that the signature verification works as expected.
 ### Keys and Signatures
 
 This module defines the following types: `KeyPair`, which contains a
-`SignKey` and `VerKey`, and a `Signature` type.  The nomenclature is
-deliberately different from the regular cryptography to emphasise the
-API-instability as well as the slightly different roles that these
-keys play in the BLS12 context as opposed to the Edwards-family.  The
-structures are give as much ABI-stability as possible, and their
-fixed-size representations are controlled via the `FixedByteRepr`
-trait.  Their sizes must not be altered, otherwise, undefined
-behaviour can be invoked. 
+`SignKey` and `VerKey`, and a `Signature` type as well as the
+`algebra` module from which we are only interested in the
+`GeneratorPoint` type.  The nomenclature is deliberately different
+from the regular cryptography to emphasise the API-instability as well
+as the slightly different roles that these keys play in the BLS12
+context as opposed to the Edwards-family.  The structures are give as
+much ABI-stability as possible, and their fixed-size representations
+are controlled via the `FixedByteRepr` trait.  Their sizes must not be
+altered, otherwise, undefined behaviour can be invoked.
 
 The main useful traits are implemented, if a trait is missing, it has
 been omitted deliberately.  Particularly, the `Ord` and `Eq` family
@@ -215,4 +216,73 @@ tested.
 # Code Details
 
 In this section I shall explain some of the aspects of the
-implementation so that the code is easier to maintain. 
+implementation so that the code is easier to maintain.  The code is
+organised in a top-down manner, with important aspects of the code
+defined first.  The vast majority of the group algebra is encapsulated
+in the module `algebra`. 
+
+## (Optional) Algebra
+
+As stated, the implementation makes use of the Apache-Milagro
+cryptographic library (AMCL) of version 3, which includes
+implementations for the most important group operations and big number
+operations.  It is also what defines the allowable levels of entropy
+in the seed phrases and the sizes of objects are derived from the
+objects in the AMCL.
+
+While it would be useful for further audits to allow an explanation of
+all the imported terms, those terms are defined in the modules and are
+not defined in any other implementation, including Hyperledger Ursa. 
+
+
+At this point it is useful to define the `PointPair` structure, which
+is the representation of a pair of points.  From a group operation
+point of view it is what allows one to verify the cryptographic
+signature.  The main point being that if `amcl::bn254::pair::isunity`
+is applied to the product of creating a `PointPair`, then it can be
+used to verify that the `PointPair` contains two representations of
+the same group element.  In other words, that the points are ''Equal''
+under the group operations.
+
+Key to understanding the BLS12 Signature verification scheme is that
+there are two groups G1 and G2, which are adjoint (in the category
+theory sense), to the elliptic curve in affine coordinate
+representation.  What this means is that to represent a point in the
+2-D space, one only needs one large index, an affine coordinate.  Thus
+there are points which are considered as belonging to group G1 and
+group G2, and their representations are in the affine co-ordinate
+systems.  Points can be overlaid on top of each other, but their
+belonging to each group is an external label, rather than an
+indication of internal geometric (or topological state). 
+
+Points of the G1 group are more often generated from a seed phrase,
+such that they need the generic `hash<T: sha2::Digest>` function,
+namely the `Signature`.  The `VerKey` is correspondingly a `G2`
+element, which are then connected via the `SignKey` which is an
+element of a third special sub-group; called the `GroupOrder`. 
+
+Using a `GroupOrderElement` and `GeneratorPoint` (a point from the G2
+group) one can generate a single element of `G2`, and an element of
+`G1`.  The matching between those two is done, as stated above, using
+the `PointPair` that determines if four objects belonging to two
+subgroups can be construed to form the group identity element.
+
+We only need two operations; unary negation and group multiplication
+for elements of G2.  All other operations are necessary only when
+dealing with more complex operations, such as multi signatures,
+threshold signatures etc.  Each element of G1 and G2, can be
+constructed randomly, with sufficient entropy.  Only the
+`GeneratorPoint` is supplied, with a `default` implementation; it is
+important to note that while `::new` functions are all producing
+random and non-detereministic values, by design `Default`
+implementations must provide the same value always.  It is not
+recommended to even attempt to produce a Private Key using anything
+less than 32 bytes of entropy.  By contrast, the role of the
+`GeneratorPoint` is public, and thus a fixed seed weakens the security
+less.
+
+All of the structures use the `amcl` representation for the underlying
+type.  It is useful for interoperability with other `amcl`-based
+implementations, but violating these assumptions is not a problem.
+
+## 

--- a/sdk/src/bls12-381.md
+++ b/sdk/src/bls12-381.md
@@ -1,0 +1,118 @@
+# BLS12-381 Solana Native instruction
+
+This is a README for the new functionality added by Eclipse
+Laboratories Inc. pertaining to the BLS12-381 single signature verify.
+
+## Overview
+The BLS12 curve is different to most Edwards-based encryption
+algorithms, specifically it does not have a natural affine basis, by
+that we mean that each party participating in signature/encryption
+must also choose a starting point with sufficient entropy.  In
+addition to that, the BLS curve algorithms have poor performance when
+ported to BPF, specifically because there isn't an efficient
+instruction that would map two 64-bit integers into a single 128-bit
+integer.  This effectively precludes its inclusion upstream for the
+foreseeable future.  Further, the current implementation cannot be
+considered API-stable as it has not undergone an audit, and it has
+some limitations (particularly, it doesn't take into account threshold
+signatures, n/n multi-signature schemes, as well as many other
+features unique to BLS12-381).
+
+With that said, this document shall contain an overview needed for
+both internal review, and external usage.  Without further ado. 
+
+## Implementation
+
+The current implementation relies on the Apache-Milagro Library
+version 3, ported to Rust (`amcl = 0.2.1`).  While there have been
+alternative implementations, they were ruled out because of a
+combination of not being maintained, not being complete and not having
+undergone an audit. 
+
+The current implementation, however, had been based on Apache-Milagro
+of version 2, and had been copied verbatim from the most prominent
+implementation as part of Hyperledger Ursa.  Thus, while it has not
+been actively maintained since 2021, it has been audited, and is based
+on a cryptography library that is both complete and has a longer
+development cycle, thus lending to easier maintenance. 
+
+The library itself cannot be included as a dependency because of the
+restrictions that it would impose on the entire Solana SDK, and the
+potential performance impact of using `amcl` of an earlier version
+without the constant-time implementations for most operations.
+Further, the library had been retired in favour of a larger number of
+smaller implementations, of which this can be considered one.
+
+Almost all of the new code is contained in the
+`./sdk/src/bls12_381_instruction.rs` rust module, and re-exported
+through the SDK.  Additional tests are added in the `programs`, to
+verify that the signature verification works as expected.
+
+### Keys and Signatures
+
+This module defines the following types: `KeyPair`, which contains a
+`SignKey` and `VerKey`, and a `Signature` type.  The nomenclature is
+deliberately different from the regular cryptography to emphasise the
+API-instability as well as the slightly different roles that these
+keys play in the BLS12 context as opposed to the Edwards-family.  The
+structures are give as much ABI-stability as possible, and their
+fixed-size representations are controlled via the `FixedByteRepr`
+trait.  Their sizes must not be altered, otherwise, undefined
+behaviour can be invoked. 
+
+The main useful traits are implemented, if a trait is missing, it has
+been omitted deliberately.  Particularly, the `Ord` and `Eq` family
+are implemented to the maximal extent that does not defy intuition.
+With that said, sometimes, two signatures can be identical, but fail
+to verify, while at the same time, two different `Signature`
+structures can be representations of the same group element. 
+
+The size of most structures is given as an integer factor of something
+known as `MODBYTES`, which is canonically set to be `32` bytes.  The
+largest structures are derived from `G1` group elements, which are the
+size of `16*32 = 512` bytes, or half a kilobyte. With that said,
+because the size is almost always fixed, it is recommended to avoid
+indirection when handling objects of type `Signature`, and instead
+rely on the stack representation as much as possible. 
+
+
+### Usage walk through
+
+#### GeneratorPoint
+
+The test `sig_verify` in the same module is a detailed explanation of
+the usual steps involved in using a BLS12-381 signature scheme.
+
+Firstly, as opposed to the Edwards family of encryption curves, all
+parties should agree on an initial `GeneratorPoint`.  This value is
+vital to the operation of the entire encryption scheme and everyone
+participating in the sig-verify handshake must be made aware of the
+exact same generator point.  If the parties disagree on the generator
+point, their signatures, and keys cannot be used interchangeably.
+
+An implementation of `core::default::Default` is provided for the
+`GeneratorPoint` for testing purposes only.  One is strongly advised
+to improve the strength of the encryption by using a more complex seed
+phrase.  While it is tempting to seed the phrase with the name of
+one's application, or the network name, the minimum entropy needed for
+`GeneratorPoint** is at least 128 **bytes**.  It is usually much
+better to create a `random_seed` and share that.  Do not throw away
+the `GeneratorPoint` after use, unless you know what you're doing. 
+
+```rust
+/// This is not a cryptographically safe seed, and it should **never**
+/// be hard-coded into your program, but rather stored securely and
+/// imported when necessary.
+let GENERATOR_POINT_SEED = [1_u8; 128];
+
+fn init () -> {
+    // ...
+    let generator_point = GeneratorPoint::from_seed(&GENERATOR_POINT_SEED);
+}
+
+```
+
+#### KeyPair
+
+Using a `GeneratorPoint` one can generate a pair of keys, which can
+then be tracked together or separately. This is for the use-case of 

--- a/sdk/src/bls12_381_instruction.rs
+++ b/sdk/src/bls12_381_instruction.rs
@@ -310,8 +310,8 @@ pub mod algebra {
 
     impl Default for GeneratorPoint {
         fn default() -> Self {
-            let mut seed_buffer = vec![0_u8; 128];
-            Self::seed_into(&mut seed_buffer)
+            let seed_buffer = [0_u8; 128];
+            Self::from_seed(&seed_buffer).unwrap()
         }
     }
 
@@ -324,11 +324,10 @@ pub mod algebra {
             }
         }
 
-        /// Construct [`Self`] from a seed.
-        pub fn seed_into(seed: &mut [u8]) -> Self {
+        /// Construct [`Self`] given a seed of precisely 128 bytes of entropy.
+        pub fn from_seed(seed: &[u8]) -> Result<Self, Error> {
             let randnum = {
-                let mut rng = rand::thread_rng();
-                rand::RngCore::fill_bytes(&mut rng, seed);
+                goof::assert_eq(&seed.len(), &128usize)?;
                 let mut rng = amcl::rand::RAND::new();
                 rng.clean();
                 rng.seed(seed.len(), seed);
@@ -353,7 +352,7 @@ pub mod algebra {
                 ))
             };
 
-            Self { point }
+            Ok(Self { point })
         }
     }
 }

--- a/sdk/src/bls12_381_instruction.rs
+++ b/sdk/src/bls12_381_instruction.rs
@@ -211,6 +211,14 @@ pub mod algebra {
         BIG::randomnum(&BIG::new_ints(&CURVE_ORDER), &mut rng)
     }
 
+    /// Generate a random seed for use with [`GeneratorPoint::from_seed`].
+    pub fn random_seed() -> [u8; 128] {
+        let mut buffer = [0; 128];
+        let mut rng = rand::thread_rng();
+        rand::RngCore::fill_bytes(&mut rng, &mut buffer);
+        buffer
+    }
+
     /// An element of the `G1` group, represented in Affine coordinates via the [`amcl`] library.
     #[derive(Debug, Clone, Copy, PartialEq)]
     #[must_use]
@@ -735,8 +743,8 @@ mod test {
         // assert_ne!(signature, different_gen_signature);
         assert!(
             !different_gen_signature
-            .verify(&message, &ver_key, different_gen)
-            .unwrap(),
+                .verify(&message, &ver_key, different_gen)
+                .unwrap(),
             "Different generator points cannot be paired post-hoc."
         );
 

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -46,7 +46,7 @@ pub use solana_program::{
     account_info, address_lookup_table_account, alt_bn128, big_mod_exp, blake3, borsh, borsh0_10,
     borsh0_9, bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable, clock, config,
     custom_heap_default, custom_panic_default, debug_account_data, declare_deprecated_sysvar_id,
-    declare_sysvar_id, decode_error, ed25519_program, epoch_schedule, fee_calculator,
+    declare_sysvar_id, decode_error, ed25519_program, bls12_381_program, epoch_schedule, fee_calculator,
     impl_sysvar_get, incinerator, instruction, keccak, lamports, loader_instruction,
     loader_upgradeable_instruction, loader_v4, loader_v4_instruction, message, msg, native_token,
     nonce, program, program_error, program_memory, program_option, program_pack, rent, sanitize,


### PR DESCRIPTION
#### Problem

The current implementation of BLS12-381 is only available as an SDK plugin. In order to make use of parallelism and other optimisations, we ought to have a native program for Solana that can be used inside programs efficiently. 

#### Summary of Changes
Fixes #4 
